### PR TITLE
Adding basic linux support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,20 @@
 
 RED2Launcher::RED2Launcher()
 {
+	// Change working directory in case someone start the launcher from another directory.
+	#ifdef PLATFORM_LINUX
+		char path_buff[PATH_MAX];
+    	ssize_t len = readlink("/proc/self/exe", path_buff, sizeof(path_buff) - 1);
+		if (len != -1 ) {
+    		std::string path_with_exe = std::string(path_buff);
+      		size_t last_slash =  path_with_exe.find_last_of("/");
+	  		chdir(path_with_exe.substr(0, last_slash).c_str());
+    	} else {
+    		Exclamation("Cannot change working directory of the process");
+    		Exit(-1);
+    	}
+	#endif
+	
 	CtrlLayout(*this, "Driver 2 PC");
 
 	logoImg.SetImage(LauncherImages::Logo());
@@ -41,6 +55,9 @@ void RED2Launcher::LaunchGame()
 	{
 		Exclamation("Unable to launch game!");
 	}
+#endif
+#ifdef PLATFORM_LINUX
+	execl("REDRIVER2", (char *) NULL);
 #endif
 }
 

--- a/setupwin.cpp
+++ b/setupwin.cpp
@@ -5,13 +5,18 @@
 #include "iso9660_dump.h"
 
 void RunJPSXDec(const char* imageFilename)
-{
-	const char* indexesFile = "install\\idxfile.tmp";
-	
+{	
 #ifdef PLATFORM_WIN32
+	const char* indexesFile = "install\\idxfile.tmp";
 	system(Format("java -jar install\\jpsxdec.jar -f \"%s\" -x \"%s\"\n", imageFilename, indexesFile));
 	system(Format("java -jar install\\jpsxdec.jar -x \"%s\" -a video -quality psx -vf avi:mjpg -up Lanczos3", indexesFile));
 	system(Format("java -jar install\\jpsxdec.jar -x \"%s\" -a audio -quality psx -af wav", indexesFile));
+#endif
+#ifdef PLATFORM_LINUX
+	const char* indexesFile = "install/idxfile.tmp";
+	system(Format("java -jar install/jpsxdec.jar -f \"%s\" -x \"%s\"\n", imageFilename, indexesFile));
+	system(Format("java -jar install/jpsxdec.jar -x \"%s\" -a video -quality psx -vf avi:mjpg -up Lanczos3", indexesFile));
+	system(Format("java -jar install/jpsxdec.jar -x \"%s\" -a audio -quality psx -af wav", indexesFile));
 #endif
 }
 


### PR DESCRIPTION
This PR adds basic linux support for the launcher which fix the first and second point of #4. 
I'm not a C/C++ programmer so let me know if you spot any errors, etc.
I've tested the launcher on Ubuntu 20.04 in a VM with Nvidia proprietary drivers and everything seems to work correctly.
I also plan to add an option to choose the SDL video driver (X11 or Wayland) and Java detection.

Right now my next priority is to add the launcher to the Flatpak release. (for #3)
Thanks!